### PR TITLE
Pattern Perm description duplicate text fix

### DIFF
--- a/Source/src/ReplicatedStorage/BaseLibrary/ItemsLibrary/init.lua
+++ b/Source/src/ReplicatedStorage/BaseLibrary/ItemsLibrary/init.lua
@@ -649,7 +649,7 @@ function ItemsLibrary:Init(super)
 		OnAdd = function(data)
 			data.PatPerm = true;
 			data.Name = data.Name .." Skin";
-			data.Description = "Right click to apply "..data.Name.." skin to a tool.";
+			data.Description = "Right click to apply "..data.Name.." to a tool.";
 		end;
 		TradingTax=100;
 	};


### PR DESCRIPTION
Fixed duplicate text in the description of Pattern Perms.

![image](https://github.com/user-attachments/assets/4aaffe92-d456-47c6-ab68-289a6570d86f)
