### PR TITLE
Added missing generic descriptions for Hyper Damage and Damage Rev

### DIFF
--- a/Source/src/ReplicatedStorage/BaseLibrary/ItemModsLibrary/init.lua
+++ b/Source/src/ReplicatedStorage/BaseLibrary/ItemModsLibrary/init.lua
@@ -20,6 +20,8 @@ local GenericDescs={
 	AmmoCap="Adds <b>Magazine Size</b> to <b>Ammo Capacity</b>.";
 	AmmoMag="Adds bullets to <b>Magazine Size</b>.";
 	HappyAuto="Adds <b>Magazine Size</b> to <b>Ammo Capacity</b> and switch <b>TriggerMode</b> from <b>Semi-automatic</b> to <b>Full-automatic</b>.";
+	HyperDamage="Adds <b>Damage</b> based on <b>Premod Damage</b> and adds <b>Rpm</b> to <b>Fire Rate</b>.";
+	DamageRev="Damage revs up for every shot you have left in your magazine. The last bullet in the magazine will do an additional <b>Multiplier</b> damage.";
 	
 	Skullcracker="Adds multiplier to <b>Headshot Multiplier</b>.";
 	Calibre="Shift your weapon's <b>Fire Rate</b> in proportional from <b>DPS</b> towards <b>Damage</b>.";

--- a/Source/src/ReplicatedStorage/BaseLibrary/ItemsLibrary/init.lua
+++ b/Source/src/ReplicatedStorage/BaseLibrary/ItemsLibrary/init.lua
@@ -649,7 +649,7 @@ function ItemsLibrary:Init(super)
 		OnAdd = function(data)
 			data.PatPerm = true;
 			data.Name = data.Name .." Skin";
-			data.Description = "Right click to apply "..data.Name.." skin to a tool.";
+			data.Description = "Right click to apply "..data.Name.." to a tool.";
 		end;
 		TradingTax=100;
 	};


### PR DESCRIPTION
Previously showed this on the items' descriptions
![image](https://github.com/user-attachments/assets/9be9df7c-23ee-4123-ba5f-eab557f30a08)
![image](https://github.com/user-attachments/assets/8f118cff-9534-40d3-95f1-18e5ed8ea540)
