### PR TITLE
Added missing damageRatio value to expGain formula

### DIFF
--- a/datamodel/rotd/ServerScriptService/ServerLibrary/NpcComponents/DeathHandler.luau
+++ b/datamodel/rotd/ServerScriptService/ServerLibrary/NpcComponents/DeathHandler.luau
@@ -160,7 +160,7 @@ function Component:__call(damagedata: DamageData)
 
 				local weaponLevel = storageItem:GetValues("L") or 0;
 				local expPool = rawProperties.ExperiencePool or 20;
-				local expGain = math.clamp(expPool - weaponLevel, 1, expPool);
+				local expGain = math.clamp((expPool - weaponLevel) * damageRatio, 1, expPool);
 
 				if storageItem.StorageId == "portableautoturret" then
 					expGain = math.ceil(expGain * 0.25);


### PR DESCRIPTION
So in the code there is unused variable `damageRatio`.

			local totalDamage = 0;
			for siid, weaponData in pairs(logData) do
				totalDamage = totalDamage + weaponData.Damage;
			end
			
			for siid, weaponData in pairs(logData) do
				local storageItem: StorageItem = weaponData.StorageItem;
				local damageRatio = math.clamp(weaponData.Damage/totalDamage, 0, 1);

I added it to the expGain formula.

In game player can use fully maxed weapon to lvl a weak weapon or lvl entire inventory worth of weapons in quick succession.
So hopefully this code change fixes the issue.


I don't know what change is on line 182 as I didn't touch that.