### PR TITLE
Removed witherers from hitlist in portableautoturret.luau

### DIFF
--- a/datamodel/rotd/ReplicatedStorage/Library/ItemsLibraryRotd/portableautoturret.luau
+++ b/datamodel/rotd/ReplicatedStorage/Library/ItemsLibraryRotd/portableautoturret.luau
@@ -10,7 +10,6 @@ local HitListBitFlag;
 
 function itemPackage.GetTurretConfigs()
 	local defaultHitlistBitString = HitListBitFlag.Size; -- all bits =1
-	defaultHitlistBitString = HitListBitFlag:Set(defaultHitlistBitString, "Witherer", false);
 	
 	return {
 		TargetDistancePriority={
@@ -91,9 +90,8 @@ function itemPackage.Init(itemLib)
 	HitListBitFlag:AddFlag("Growler", 6);
 	HitListBitFlag:AddFlag("Dr. Sinister", 7);
 	HitListBitFlag:AddFlag("Tendrils", 8);
-	HitListBitFlag:AddFlag("Witherer", 9);
-	HitListBitFlag:AddFlag("Bandit", 10);
-	HitListBitFlag:AddFlag("Bosses", 11);
+	HitListBitFlag:AddFlag("Bandit", 9);
+	HitListBitFlag:AddFlag("Bosses", 10);
 
 	--== MARK: Server
 	if RunService:IsClient() then return end;


### PR DESCRIPTION
Witherers are set to detectable = false, so the portableautoturret is incapable to attack it regardless of hitlist configurations.

Alternatively some rule could be created that witherers are detectable exclusively for the turret, unfortunately I wouldn't quite know how to code that in.